### PR TITLE
Avoid Exception when queue is full

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.10.49</version>
+                <version>1.11.271</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/src/main/java/org/bricolages/mys3dump/MyS3Dump.java
+++ b/src/main/java/org/bricolages/mys3dump/MyS3Dump.java
@@ -92,8 +92,10 @@ public class MyS3Dump {
                 .collect(Collectors.<CompletableFuture<WorkerResult>>toList());
     }
 
-    private void addEOFSignal(BlockingQueue<char[][]> queue, int num) {
-        IntStream.range(0, num).forEach(dummy -> queue.add(new char[0][0]));
+    private void addEOFSignal(BlockingQueue<char[][]> queue, int num) throws InterruptedException {
+        for (int i = 0; i < num; i++) {
+            queue.put(new char[0][0]);
+        }
     }
 
     private Long totalRowCount(List<WorkerResult> results) throws InterruptedException, ExecutionException {


### PR DESCRIPTION
Current: Throws error when queue is full.
This PR: Block when queue is full.

Want to block thread when queue is full to avoid program exit.