### PR TITLE
Avoid SQL syntax error when a table doesn't exist

### DIFF
--- a/src/main/java/org/bricolages/mys3dump/MyS3Dump.java
+++ b/src/main/java/org/bricolages/mys3dump/MyS3Dump.java
@@ -2,6 +2,8 @@ package org.bricolages.mys3dump;
 
 import org.apache.commons.cli.*;
 import org.apache.log4j.Logger;
+import org.bricolages.mys3dump.exception.ApplicationException;
+import org.bricolages.mys3dump.exception.EmptyTableException;
 
 import java.io.IOException;
 import java.sql.*;
@@ -13,7 +15,7 @@ import java.util.stream.IntStream;
 public class MyS3Dump {
     static private final Logger logger = Logger.getLogger(MyS3Dump.class);
 
-    public static void main(String[] args) throws ParseException, IOException, ClassNotFoundException, SQLException, ExecutionException, InterruptedException {
+    public static void main(String[] args) throws ParseException, IOException, ClassNotFoundException, SQLException, ExecutionException, InterruptedException, ApplicationException {
         Parameters params = new Parameters(args);
         MySQLDataSource myds = new MySQLDataSource(params.getHost(), params.getPort(), params.getDatabase(), params.getUsername(), params.getPassword(), params.getConnectionProperty());
         try {

--- a/src/main/java/org/bricolages/mys3dump/MySQLDataSource.java
+++ b/src/main/java/org/bricolages/mys3dump/MySQLDataSource.java
@@ -1,6 +1,7 @@
 package org.bricolages.mys3dump;
 
 import org.apache.log4j.Logger;
+import org.bricolages.mys3dump.exception.ApplicationException;
 
 import java.sql.*;
 import java.util.ArrayList;
@@ -15,6 +16,7 @@ class MySQLDataSource {
     private final String connectionString;
     private final String username;
     private final String password;
+    private DatabaseMetaData metadata;
 
     public MySQLDataSource(String host, int port, String db, String username, String password, String property) throws ClassNotFoundException {
         this.connectionString = "jdbc:mysql://" + host + ":" + port + "/" + db + "?" + property;
@@ -26,6 +28,13 @@ class MySQLDataSource {
     Connection newConnection() throws SQLException {
         logger.info("Connecting to: " + this.connectionString);
         return DriverManager.getConnection(connectionString, username, password);
+    }
+
+    DatabaseMetaData getDatabaseMetaData() throws SQLException {
+        if (metadata == null) {
+            metadata = newConnection().getMetaData();
+        }
+        return metadata;
     }
 
     <T> List<List<T>> execute(String sql, Class<T> cls) throws SQLException {
@@ -55,12 +64,15 @@ class MySQLDataSource {
         }
     }
 
-    ResultSetSchema getTableSchema(String table) throws SQLException {
-        DatabaseMetaData meta = newConnection().getMetaData();
+    ResultSetSchema getTableSchema(String table) throws SQLException, ApplicationException {
+        DatabaseMetaData meta = getDatabaseMetaData();
         try (ResultSet rs = meta.getColumns(null, null, table, "%")) {
             List<ResultSetColumn> columns = new ArrayList<>();
             while (rs.next()) {
                 columns.add(new ResultSetColumn(rs.getString("COLUMN_NAME"), rs.getInt("DATA_TYPE"), rs.getString("TYPE_NAME")));
+            }
+            if (columns.size() == 0) {
+                throw new ApplicationException(String.format("Table %s doesn't exist", table));
             }
             return new ResultSetSchema(columns);
         }

--- a/src/main/java/org/bricolages/mys3dump/ScanQueryBuilder.java
+++ b/src/main/java/org/bricolages/mys3dump/ScanQueryBuilder.java
@@ -1,6 +1,9 @@
 package org.bricolages.mys3dump;
 
 import org.apache.log4j.Logger;
+import org.bricolages.mys3dump.exception.ApplicationException;
+import org.bricolages.mys3dump.exception.EmptyTableException;
+
 import java.sql.SQLException;
 import java.util.Collections;
 import java.util.List;
@@ -25,7 +28,7 @@ class ScanQueryBuilder {
         this.tableName = tableName;
     }
 
-    public List<ScanQuery> getScanQueries() throws SQLException {
+    public List<ScanQuery> getScanQueries() throws SQLException, ApplicationException {
         ResultSetSchema schema = this.dataSource.getTableSchema(tableName);
         if (hasPartitionInfo()) {
             return newPartitionStream().map(part -> new ScanQuery(getQueryWithPlaceHolder(schema), new Partition(partitionColumn, part.start, part.end))).collect(Collectors.toList());

--- a/src/main/java/org/bricolages/mys3dump/exception/ApplicationError.java
+++ b/src/main/java/org/bricolages/mys3dump/exception/ApplicationError.java
@@ -1,0 +1,11 @@
+package org.bricolages.mys3dump.exception;
+
+public class ApplicationError extends RuntimeException {
+    public ApplicationError(String message) {
+        super(message);
+    }
+
+    public ApplicationError(Exception cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/bricolages/mys3dump/exception/ApplicationException.java
+++ b/src/main/java/org/bricolages/mys3dump/exception/ApplicationException.java
@@ -1,0 +1,11 @@
+package org.bricolages.mys3dump.exception;
+
+public class ApplicationException extends Exception {
+    public ApplicationException(String message) {
+        super(message);
+    }
+
+    public ApplicationException(Exception cause) {
+        super(cause);
+    }
+}

--- a/src/main/java/org/bricolages/mys3dump/exception/EmptyTableException.java
+++ b/src/main/java/org/bricolages/mys3dump/exception/EmptyTableException.java
@@ -1,9 +1,9 @@
-package org.bricolages.mys3dump;
+package org.bricolages.mys3dump.exception;
 
 /**
  * Created by shimpei-kodama on 2016/02/22.
  */
-class EmptyTableException extends RuntimeException {
+public class EmptyTableException extends RuntimeException {
     public EmptyTableException(String table) {
         super(table + " is empty.");
     }

--- a/src/test/java/org/bricolages/mys3dump/MySQLDataSourceTest.java
+++ b/src/test/java/org/bricolages/mys3dump/MySQLDataSourceTest.java
@@ -1,0 +1,36 @@
+package org.bricolages.mys3dump;
+
+import org.bricolages.mys3dump.exception.ApplicationException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class MySQLDataSourceTest {
+
+    @Test
+    void getTableSchema_nonexistentTable() throws SQLException, ClassNotFoundException {
+        ResultSet rs = mock(ResultSet.class);
+        when(rs.next()).thenReturn(false);
+        DatabaseMetaData meta = mock(DatabaseMetaData.class);
+        when(meta.getColumns(any(),any(),any(),any())).thenReturn(rs);
+        MySQLDataSource ds = new MySQLDataSource("", 0, "", "", "", "");
+        MySQLDataSource spy_ds = spy(ds);
+        doReturn(meta).when(spy_ds).getDatabaseMetaData();
+
+        String table_name = "test_table";
+        Exception ex = assertThrows(ApplicationException.class, () -> {
+            spy_ds.getTableSchema(table_name);
+        });
+        assertEquals(ex.getMessage(), String.format("Table %s doesn't exist", table_name));
+    }
+}

--- a/src/test/java/org/bricolages/mys3dump/ResultSetMetaDataMock.java
+++ b/src/test/java/org/bricolages/mys3dump/ResultSetMetaDataMock.java
@@ -1,0 +1,42 @@
+package org.bricolages.mys3dump;
+
+import org.mockito.Mockito;
+import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+
+class ResultSetMetaDataMock {
+
+    class Column {
+        final String name;
+        final int type;
+        final String typeName;
+
+        Column(String name, int type, String typeName) {
+            this.name = name;
+            this.type = type;
+            this.typeName = typeName;
+        }
+    }
+
+    final List<Column> cols = Arrays.asList(
+            new Column("c1", 1, "INTEGER"),
+            new Column("c2", 2, "GEOMETRY")
+    );
+
+    public ResultSetMetaData make() throws SQLException {
+        ResultSetMetaData metadata = Mockito.mock(ResultSetMetaData.class);
+        when(metadata.getColumnCount()).thenReturn(cols.size());
+        int i = 1;
+        for(ResultSetMetaDataMock.Column c : cols) {
+            when(metadata.getColumnName(i)).thenReturn(c.name);
+            when(metadata.getColumnType(i)).thenReturn(c.type);
+            when(metadata.getColumnTypeName(i)).thenReturn(c.typeName);
+            i++;
+        }
+        return metadata;
+    }
+}

--- a/src/test/java/org/bricolages/mys3dump/ResultSetSchemaTest.java
+++ b/src/test/java/org/bricolages/mys3dump/ResultSetSchemaTest.java
@@ -16,39 +16,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.when;
 
-@ExtendWith(MockitoExtension.class)
 class ResultSetSchemaTest {
 
-    @Mock
     ResultSetMetaData metadata;
-
-    class Column {
-        final String   name;
-        final int      type;
-        final String   typeName;
-
-        Column(String name, int type, String typeName) {
-            this.name = name;
-            this.type = type;
-            this.typeName = typeName;
-        }
-    }
-
-    final List<Column> cols = Arrays.asList(
-            new Column("c1", 1, "INTEGER"),
-            new Column("c2", 2, "GEOMETRY")
-    );
 
     @BeforeEach
     void init() throws Exception {
-        when(metadata.getColumnCount()).thenReturn(cols.size());
-        int i = 0;
-        for(Column c : cols) {
-            i++;
-            when(metadata.getColumnName(i)).thenReturn(c.name);
-            when(metadata.getColumnType(i)).thenReturn(c.type);
-            when(metadata.getColumnTypeName(i)).thenReturn(c.typeName);
-        }
+        metadata = (new ResultSetMetaDataMock()).make();
     }
 
     @Test
@@ -60,15 +34,15 @@ class ResultSetSchemaTest {
     @Test
     void getColumns() throws SQLException {
         ResultSetSchema schema = ResultSetSchema.newInstance(metadata);
-        assertTrue(schema.getColumns().get(0) instanceof ResultSetColumn);
+        assertTrue(schema.getColumns().get(0) != null);
     }
 
     @Test
     void getColumnTypes() throws SQLException {
         ResultSetSchema schema = ResultSetSchema.newInstance(metadata);
-        int i = 0;
+        int i = 1;
         for(int t : schema.getColumnTypes()) {
-            assertEquals(t, cols.get(i).type);
+            assertEquals(t, metadata.getColumnType(i));
             i++;
         }
     }
@@ -76,9 +50,9 @@ class ResultSetSchemaTest {
     @Test
     void getColumnNames() throws SQLException {
         ResultSetSchema schema = ResultSetSchema.newInstance(metadata);
-        int i = 0;
+        int i = 1;
         for(String t : schema.getColumnNames()) {
-            assertEquals(t, cols.get(i).name);
+            assertEquals(t, metadata.getColumnName(i));
             i++;
         }
     }


### PR DESCRIPTION
Throws ApplicationException with proper message
instead of SQLException with syntax error.