### PR TITLE
Bump mysql-connector-java from 5.1.38 to 8.0.21

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.bricolages.mys3dump</groupId>
     <artifactId>mys3dump</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0.1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
-            <version>5.1.38</version>
+            <version>8.0.21</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
Update mysql-connector-java from 5.1.38 to 8.0.21 (latest at this moment).

For https://github.com/bricolages/mys3dump/pull/7 