### PR TITLE
fix: Explicit JDBC driver class loading is not required now

### DIFF
--- a/src/main/java/org/bricolages/mys3dump/MySQLDataSource.java
+++ b/src/main/java/org/bricolages/mys3dump/MySQLDataSource.java
@@ -22,7 +22,6 @@ class MySQLDataSource {
         this.connectionString = "jdbc:mysql://" + host + ":" + port + "/" + db + "?" + property;
         this.username = username;
         this.password = password;
-        Class.forName("com.mysql.jdbc.Driver");
     }
 
     Connection newConnection() throws SQLException {


### PR DESCRIPTION
最近のJDBCドライバーは自分でドライバークラスをロードする必要なし