### PR TITLE
Use MariaDB Connector/J instead of MySQL Connector/J

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ repositories {
 }
 
 dependencies {
-    implementation("mysql:mysql-connector-java:8.0.22")
+    implementation("org.mariadb.jdbc:mariadb-java-client:2.7.1")
     implementation("com.amazonaws:aws-java-sdk-s3:1.11.932")
     implementation("ch.qos.logback:logback-classic:1.2.3")
     implementation("org.slf4j:slf4j-api:1.7.30")


### PR DESCRIPTION
MySQL Connector/Jは8.0でストリーミングモードの速度が異常に劣化しており使いものにならない。
また、Auroraの推奨ドライバーはMariaDB Connectorなので、その点でもMariaDB Connectorのほうが妥当。
最新の2.7.1ではJSON型も問題なく扱えることを確認した。