### PR TITLE
Modify escape or not for FLOAT, REAL, DOUBLE, NUMERIC and DECIMAL to load dumped json

### DIFF
--- a/src/main/java/org/bricolages/mys3dump/JSONRowFormatter.java
+++ b/src/main/java/org/bricolages/mys3dump/JSONRowFormatter.java
@@ -39,17 +39,17 @@ class JSONRowFormatter implements RowFormatter {
     char[] formatValue(char[] value, int columnType) {
         // expect value is not null
         switch (columnType) {
-            case Types.FLOAT:
-            case Types.REAL:
-            case Types.DOUBLE:
             case Types.TINYINT:
             case Types.SMALLINT:
             case Types.INTEGER:
             case Types.BIGINT:
-            case Types.NUMERIC:
-            case Types.DECIMAL:
             case Types.ARRAY:
                 return value;
+            case Types.FLOAT:
+            case Types.REAL:
+            case Types.DOUBLE:
+            case Types.NUMERIC:
+            case Types.DECIMAL:
             default:
                 return escape(value);
         }

--- a/src/main/java/org/bricolages/mys3dump/JSONRowFormatter.java
+++ b/src/main/java/org/bricolages/mys3dump/JSONRowFormatter.java
@@ -45,6 +45,7 @@ class JSONRowFormatter implements RowFormatter {
             case Types.BIGINT:
             case Types.ARRAY:
                 return value;
+            // escape as string to prevent accuracy problem when loading
             case Types.FLOAT:
             case Types.REAL:
             case Types.DOUBLE:


### PR DESCRIPTION
JSONをロードしたとき、小数点で精度が落ちて異なる値がロードされていました。
整数以外の数値型はすべて文字列としてダンプするようにします